### PR TITLE
fix for multivolume files

### DIFF
--- a/mvloader/anatomical_coords.py
+++ b/mvloader/anatomical_coords.py
@@ -153,9 +153,61 @@ def offset(perm, shape):
     return offset_matrix
 
 
-def swap(a, perm, copy=False):
+def pull_spatial_dimensions(a, spatial_dimensions, copy=False):
     """
-    Swap the values in the given volume according to the given permutation-reflection matrix.
+    Bring the given array's :math:`d` spatial dimensions to the front.
+
+    Parameters
+    ----------
+    a : array_like
+        The :math:`N`-dimensional array (:math:`N≥d`) whose spatial dimensions are to be pulled.
+    spatial_dimensions : sequence of int
+        A :math:`d`-tuple that gives the positions of the array's spatial dimensions. The first value will end up as
+        axis 0, the second one as axis 1, etc.
+    copy : bool, optional
+        If `False` (default), return a view into the given array `a`; if `True`, return an array that does not share
+        data with `a`.
+
+    Returns
+    -------
+    numpy.ndarray
+        A :math:`d`-dimensional array with the spatial dimensions along the first :math:`d` axes. The order of the
+        remaining axes is unchanged.
+    """
+    a = a.copy() if copy else a
+    a = np.moveaxis(a, source=spatial_dimensions, destination=np.arange(len(spatial_dimensions)))
+    return a
+
+
+def push_spatial_dimensions(a, spatial_dimensions, copy=False):
+    """
+    Bring the given array's :math:`d` spatial dimensions from the front back to their original position.
+
+    Parameters
+    ----------
+    a : array_like
+        The :math:`N`-dimensional array (:math:`N≥d`) whose spatial dimensions are to be pushed back.
+    spatial_dimensions : sequence of int
+        A :math:`d`-tuple that gives the original positions of the array's spatial dimensions. Axis 0 will end up at the
+        first value, axis 1 will end up at the second value, etc.
+    copy : bool, optional
+        If `False` (default), return a view into the given array `a`; if `True`, return an array that does not share
+        data with `a`.
+
+    Returns
+    -------
+    numpy.ndarray
+        A :math:`d`-dimensional array with the :math:`d` spatial dimensions along their original axes. The order of the
+        remaining axes is unchanged.
+    """
+    a = a.copy() if copy else a
+    a = np.moveaxis(a, source=np.arange(len(spatial_dimensions)), destination=spatial_dimensions)
+    return a
+
+
+def swap(a, perm, copy=False):  # FIXME: add and respect spatial_dimensions attribute
+    """
+    Swap the spatial dimensions of the given volume according to the given permutation-reflection matrix.
 
     Parameters
     ----------

--- a/mvloader/volume.py
+++ b/mvloader/volume.py
@@ -12,7 +12,8 @@ import mvloader.anatomical_coords as ac
 
 class Volume:
     """
-    Volume(src_voxel_data, src_transformation, src_system, system="RAS", src_object=None)
+    Volume(src_voxel_data, src_transformation, src_system,
+           src_spatial_dimensions=(0, 1, 2), system="RAS", src_object=None)
 
     Return an object that represents 3D image volumes in a desired anatomical world coordinate system (``system``;
     default is "RAS"), based on (1) an array that holds the voxels (``src_voxel_data``) and (2) a transformation matrix
@@ -52,7 +53,8 @@ class Volume:
         ``src_voxel_data`` and ``src_transformation`` -- for debugging, for example (default: None).
     """
 
-    def __init__(self, src_voxel_data, src_transformation, src_system, src_spatial_dimensions=(0, 1, 2), system="RAS", src_object=None):
+    def __init__(self, src_voxel_data, src_transformation, src_system,
+                 src_spatial_dimensions=(0, 1, 2), system="RAS", src_object=None):
 
         self.__src_system = src_system
         self.__user_system = None

--- a/mvloader/volume.py
+++ b/mvloader/volume.py
@@ -40,7 +40,7 @@ class Volume:
         ``src_transformation`` matrix. Any permutation of {A,P}, {I,S}, {L,R} (case-insensitive) can be used. For
         example, for voxels and a transformation matrix provided by a DICOM loading library, this should usually be
         "LPS", as this is the assumed world coordinate system of the DICOM standard.
-    src_spatial_dimensions : array_like, optional
+    src_spatial_dimensions : sequence of int, optional
         The three spatial dimensions of the array (default: (0, 1, 2)). The order of the given values is ignored, as
         the mapping order from voxel indices to the world coordinate system should be handled exclusively by the given
         ``src_transformation`` matrix.

--- a/mvloader/volume.py
+++ b/mvloader/volume.py
@@ -30,8 +30,8 @@ class Volume:
     src_voxel_data : array_like
         An :math:`N`-dimensional array (:math:`N≥3`) that contains the image voxels, arranged to match the coordinate
         transformation matrix ``src_transformation``. The array is assumed to contain a 3D image, i.e. three of its
-        dimensions (as specified via ``src_spatial_dimensions``) define its spatial dimensions while the remaining
-        :math:`N-3` dimensions are its time and/or data dimensions. If :math:`N=3`, scalar data is assumed.
+        axes (as specified via ``src_spatial_dimensions``) define its spatial dimensions while the remaining
+        :math:`N-3` axes are its time and/or data dimensions. If :math:`N=3`, scalar data is assumed.
     src_transformation : array_like
         A :math:`4×4` matrix that describes the mapping from voxel indices in ``src_voxel_data`` to the given anatomical
         world coordinate system ``src_system``.
@@ -41,9 +41,9 @@ class Volume:
         example, for voxels and a transformation matrix provided by a DICOM loading library, this should usually be
         "LPS", as this is the assumed world coordinate system of the DICOM standard.
     src_spatial_dimensions : sequence of int, optional
-        The three axes that correspond to the spatial dimensions of the array (default: (0, 1, 2)). The order of the
-        given values is ignored, as the mapping order from voxel indices to the world coordinate system should be
-        handled exclusively by the given ``src_transformation`` matrix.
+        The three axes that correspond to the spatial dimensions of the ``src_voxel_data`` array (default: (0, 1, 2)).
+        The order of the given values is ignored, as the mapping order from voxel indices to the world coordinate system
+        should be handled exclusively by the given ``src_transformation`` matrix.
     system : str, optional
         A three-character string similar to ``src_system``. However, ``system`` should describe the anatomical world
         coordinate system that the *user* assumes/desires. It will also determine the arrangement of the voxel data for

--- a/mvloader/volume.py
+++ b/mvloader/volume.py
@@ -107,7 +107,7 @@ class Volume:
         # Swap: given source array axes -> user system axes
         vsrc2suser_3x3 = ssrc2suser_3x3 @ vsrc2ssrc_3x3
 
-        offset_4x4 = ac.offset(vsrc2suser_3x3, self.__src_volume.shape)
+        offset_4x4 = ac.offset(vsrc2suser_3x3, self.__src_volume.shape[:3])
         # Transform: given source array indices -> user system aligned array indices
         vsrc2vuser_4x4 = ac.homogeneous_matrix(vsrc2suser_3x3) @ offset_4x4
         # Transform: user system aligned array indices -> given source array indices
@@ -326,7 +326,7 @@ class Volume:
 
         # Combine, calculate necessary offset, and actually swap current instance's aligned array respectively
         cur_suser_2_tpl_vsrc_3x3 = tpl_vuser_2_tpl_vsrc_3x3 @ cur_suser_2_tpl_suser_3x3
-        offset_4x4 = ac.offset(cur_suser_2_tpl_vsrc_3x3, current_instance.__aligned_volume.shape)
+        offset_4x4 = ac.offset(cur_suser_2_tpl_vsrc_3x3, current_instance.__aligned_volume.shape[:3])
         cur_vuser_2_tpl_vsrc_4x4 = ac.homogeneous_matrix(cur_suser_2_tpl_vsrc_3x3) @ offset_4x4
         cur_aligned_volume_swapped = ac.swap(current_instance.__aligned_volume, cur_vuser_2_tpl_vsrc_4x4, copy=deep)
 


### PR DESCRIPTION
Only the spatial dimensions are necessary for the reorientation of the volume. If the full shape is used, this will only work for volumetric data, and wont work for multi volume files or volumetric timeseries. 