### PR TITLE
added fix for automatic array conversion, such that memmaps are preserved

### DIFF
--- a/mvloader/nifti.py
+++ b/mvloader/nifti.py
@@ -57,7 +57,7 @@ def open_image(path, verbose=True, squeeze=False):
     except Exception as e:
         raise IOError(e)
 
-    voxel_data = np.array(src_object.get_data())
+    voxel_data = src_object.get_data()
     hdr = src_object.header
 
     ndim = hdr["dim"][0]


### PR DESCRIPTION
np.array(src_object.get_data()) converts the memmap explicitly to an array, which is not ideal for very large data. Does ommitting it result in any problems?